### PR TITLE
Remove `MSSQL_PID`

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -122,7 +122,7 @@ forceencryption = 1
         }
 
         Write-Output "Starting a Docker Container"
-        Invoke-Expression "docker run --name=`"sql`" -e `"ACCEPT_EULA=Y`"-e `"SA_PASSWORD=$SaPassword`" -e `"MSSQL_PID=Express`" --health-cmd=`"$ToolsPath/bin/sqlcmd -C -S localhost -U sa -P '$SaPassword' -Q 'SELECT 1' -b -o /dev/null`" --health-start-period=`"10s`" --health-retries=3 --health-interval=`"10s`" -p 1433:1433 $AdditionalContainerConfiguration -d `"mcr.microsoft.com/mssql/server:$Version-$Tag`""
+        Invoke-Expression "docker run --name=`"sql`" -e `"ACCEPT_EULA=Y`"-e `"SA_PASSWORD=$SaPassword`" --health-cmd=`"$ToolsPath/bin/sqlcmd -C -S localhost -U sa -P '$SaPassword' -Q 'SELECT 1' -b -o /dev/null`" --health-start-period=`"10s`" --health-retries=3 --health-interval=`"10s`" -p 1433:1433 $AdditionalContainerConfiguration -d `"mcr.microsoft.com/mssql/server:$Version-$Tag`""
         Wait-ForContainer
     }
 


### PR DESCRIPTION
I see some strange timeout issues on other repositories. It could be that "Express" edition behaves different under certain conditions. By removing `MSSQL_PID`, we go back to the default value, which is `Developer`.